### PR TITLE
Add post-timer labels

### DIFF
--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -133,13 +133,13 @@ function setToCurrentTime(labels) {
 	};
 }
 
-function startTimer(labels) {
+function startTimer(startLabels) {
 	var gauge = this;
 	return function() {
 		var start = new Date();
-		return function() {
+		return function(endLabels) {
 			var end = new Date();
-			gauge.set(labels, (end - start) / 1000);
+			gauge.set(extend(startLabels || {}, endLabels), (end - start) / 1000);
 		};
 	};
 }

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -107,13 +107,13 @@ Histogram.prototype.labels = function() {
 	};
 };
 
-function startTimer(labels) {
+function startTimer(startLabels) {
 	var histogram = this;
 	return function() {
 		var start = new Date();
-		return function() {
+		return function(endLabels) {
 			var end = new Date();
-			histogram.observe(labels, (end - start) / 1000);
+			histogram.observe(extend(startLabels || {}, endLabels), (end - start) / 1000);
 		};
 	};
 }

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -142,7 +142,7 @@ function startTimer(startLabels) {
 		var start = new Date();
 		return function(endLabels) {
 			var end = new Date();
-			summary.observe(extend(startLabels, endLabels), (end - start) / 1000);
+			summary.observe(extend(startLabels || {}, endLabels), (end - start) / 1000);
 		};
 	};
 }

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+// testing
+
 var register = require('./register');
 var type = 'summary';
 var isNumber = require('./util').isNumber;

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -3,8 +3,6 @@
  */
 'use strict';
 
-// testing
-
 var register = require('./register');
 var type = 'summary';
 var isNumber = require('./util').isNumber;
@@ -138,16 +136,17 @@ Summary.prototype.labels = function() {
 	};
 };
 
-function startTimer(labels) {
+function startTimer(startLabels) {
 	var summary = this;
 	return function() {
 		var start = new Date();
-		return function() {
+		return function(endLabels) {
 			var end = new Date();
-			summary.observe(labels, (end - start) / 1000);
+			summary.observe(extend(startLabels, endLabels), (end - start) / 1000);
 		};
 	};
 }
+
 function validateInput(name, help, labels) {
 	if(!help) {
 		throw new Error('Missing mandatory help parameter');


### PR DESCRIPTION
Allow for post-timer labelling, for use cases like adding error/success labels:

``` javascript
var promClient = require('prom-client');
var metric = promClient.metric('metric_name', 'metric_help', ['success_response']);

var timer = metric.startTimer();
someFunction((err, result) => {
  if (err) {
    timer({ success_response: 'ERROR' });
    console.log('uh-oh');
  } else {
    timer({ success_response: 'SUCCESS' });
    console.log('yay!');
  }
})
```
